### PR TITLE
cookbook uploaded to supermarket missing library files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ f5-bigip Cookbook CHANGELOG
 ==============================
 This file is used to list changes made in each version of the f5-bigip cookbook.
 
+v0.4.1
+------
+* Uptick to re-upload to supermarket after encountering CHEF-672 which caused knife to upload with missing library files
+
 v0.4.0
 ------
 * Initial Release

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'jacob.mccann2@target.com'
 license          'Apache 2.0'
 description      'Installs/Configures f5-icontrol'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.4.0'
+version          '0.4.1'
 
 depends 'chef-vault'


### PR DESCRIPTION
Uploaded cookbook to supermarket with chef 11.16.4 which has bug
[CHEF-672](https://github.com/opscode/chef/pull/760) causing library files in subdirs to be ignored.  Updated
workstation to chef 12.0.3 which includes fix for the bug.  Need
to uptick the version in order to reupload to supermarket.