### PR TITLE
Add support for non-ip node name to f5_ltm_node

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This definition is a wrapper for the [`f5_ltm_node`](#f5_ltm_node), [`f5_ltm_poo
 |    Attr   |   Default/Req?    |    Type    |       Description        |
 |-----------|-------------------|------------|--------------------------|
 | f5        | **REQUIRED**    | String     | f5 to create the node on |
-| nodes | **REQUIRED** | Array[String] | Nodes to load balance the VIP against |
+| nodes | **REQUIRED** | Array[String] | Nodes (ip addresses) to load balance the VIP against |
 | pool | **REQUIRED** | String | Name to create node with |
 | lb_method | `LB_METHOD_ROUND_ROBIN` | String | Load balancing method |
 | monitors | [] | Array[String] | Monitors to check that nodes are available |
@@ -60,6 +60,11 @@ f5_vip 'testing.test.com' do
   destination_address '192.168.1.10'
 end
 ```
+
+It will create
+* Two nodes, named after their ip addresses
+* A pool referencing the nodes as members with no monitors
+* A virtual server listening on `<destination_address>:443`
 
 A fully user defined VIP:
 ```ruby
@@ -97,16 +102,29 @@ f5_ltm_node
 
 ### Attributes
 
-|    Attr   |   Default/Req?    |    Type    |       Description        |
-|-----------|-------------------|------------|--------------------------|
-| node_name | The resource name | String     | Name to create node with |
-| f5        | **REQUIRED**    | String     | f5 to create the node on |
-| enabled   | `true`            | true/false | State node should be in  |
+|    Attr   |   Default/Req?    |    Type    |       Description              |
+|-----------|-------------------|------------|--------------------------------|
+| node_name | The resource name | String     | Name to create node with       |
+| address   | `node_name`       | String     | IP address to create node with |
+| f5        | **REQUIRED**      | String     | f5 to create the node on       |
+| enabled   | `true`            | true/false | State node should be in        |
 
-### Example
+If the `address` attribute is unset, the `node_name` (which in turn defaults to the resource's name) will be used instead.
 
+### Examples
+
+The following creates a node with name and address of `10.10.10.10`:
 ```ruby
 f5_ltm_node '10.10.10.10' do
+  f5 'f5-test.test.com'
+  enabled true
+end
+```
+
+The following creates a node named `test-node.test.com` with `10.10.10.10` as the ip address:
+```ruby
+f5_ltm_node 'test-node.test.com' do
+  address '10.10.10.10'
   f5 'f5-test.test.com'
   enabled true
 end

--- a/libraries/provider_ltm_node.rb
+++ b/libraries/provider_ltm_node.rb
@@ -65,7 +65,7 @@ class Chef
       def create_node
         converge_by("Create #{new_resource}") do
           Chef::Log.info "Create #{new_resource}"
-          load_balancer.client['LocalLB.NodeAddressV2'].create([new_resource.node_name], [new_resource.node_name], [0])
+          load_balancer.client['LocalLB.NodeAddressV2'].create([new_resource.node_name], [new_resource.address], [0])
           current_resource.enabled(true)
 
           new_resource.updated_by_last_action(true)

--- a/libraries/resource_ltm_node.rb
+++ b/libraries/resource_ltm_node.rb
@@ -42,6 +42,14 @@ class Chef
         set_or_return(:node_name, arg, :kind_of => String, :required => true)
       end
 
+      def address(arg = nil)
+        if arg.nil? && @address.nil?
+          set_or_return(:address, @node_name, :kind_of => String, :required => true)
+        else
+          set_or_return(:address, arg, :kind_of => String, :required => true)
+        end
+      end
+
       def f5(arg = nil)
         set_or_return(:f5, arg, :kind_of => String, :required => true)
       end


### PR DESCRIPTION
Currently, the `node_name` attribute of a `f5_ltm_node` resource is used as the ip address and object name for the node to create in LTM. It is not possible to create nodes with a name other than the ip address.

To allow the creation of nodes with object names differing from the ip address, the following would have to be done:
* Add `address` attribute to `f5_ltm_node` resource, defaulting to `node_name` for backward compatibility
* Change call of `client['LocalLB.NodeAddressV2'].create` to use the new attribute
* Document new attribute
* Change documentation to reflect that the node (object) name must be used as address in `f5_ltm_pool` `members` attribute
* Add documentation to `f5_vip` definition, indicating that it will create node objects in LTM with object name matching ip address