### PR TITLE
Partitions support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ This definition is a wrapper for the [`f5_ltm_node`](#f5_ltm_node), [`f5_ltm_poo
 | default_persistence_profile | '' | String | Default persistence profile to associate with virtual server |
 | fallback_persistence_profile | '' | String | Fallback persistence profile to associate with virtual server |
 | rules | [] | Array[String] | iRules to associate with virtual server |
+| partition | '' | String | Partition name where to create this VIP. It must exist. |
 
 ### Example
 The simplest VIP declartion that takes as many defaults as possible:
@@ -112,6 +113,8 @@ f5_ltm_node
 
 If the `address` attribute is unset, the `node_name` (which in turn defaults to the resource's name) will be used instead.
 
+`node_name` can be prefixed with a partition name, for example `/internal/node_name`. Default is `/Common`.
+
 ### Examples
 
 The following creates a node with name and address of `10.10.10.10`:
@@ -144,6 +147,8 @@ f5_ltm_pool
 | lb_method | `LB_METHOD_ROUND_ROBIN` | String | Load balancing method |
 | monitors | [] | Array[String] | Monitors to check that pool members are available |
 | members | [] | Array[Hash] | Members to add to the pool |
+
+`pool_name` can be prefixed with a partition name, for example `/internal/pool_name`. Default is `/Common`.
 
 ### Example
 
@@ -185,6 +190,8 @@ f5_ltm_monitor
 | dest_addr_port | 443 | Integer | Port |
 | user_values | {} | Hash | Hash of user specific values |
 
+`monitor_name` can be prefixed with a partition name, for example `/internal/monitor_name`. Default is `/Common`.
+
 ### Example
 
 ```ruby
@@ -218,6 +225,8 @@ f5_ltm_virtual_server
 | fallback_persistence_profile | '' | String | Fallback persistence profile to associate with virtual server |
 | rules | [] | Array[String] | iRules to associate with virtual server |
 | enabled | true | true/false | Enable or disable the virtual server |
+
+`vs_name` can be prefixed with a partition name, for example `/internal/vs_name`. Default is `/Common`.
 
 ### Example
 

--- a/definitions/vip.rb
+++ b/definitions/vip.rb
@@ -8,6 +8,7 @@
 define :f5_vip, :member_port => 443, :monitors => [], :lb_method => nil, :vlan_state => nil, :vlans => [],
                 :destination_port => 443, :profiles => [], :snat_type => nil, :snat_pool => nil,
                 :default_persistence_profile => nil, :fallback_persistence_profile => nil,
+                :partition => '/Common',
                 :rules => [] do
 
   name = params[:name]
@@ -17,7 +18,8 @@ define :f5_vip, :member_port => 443, :monitors => [], :lb_method => nil, :vlan_s
 
   params[:nodes].each do |node|
     f5_ltm_node "#{params[:f5]}-#{node}" do
-      node_name node
+      node_name "#{params[:partition]}/#{node}"
+      address node
       f5 params[:f5]
       notifies :run, "f5_config_sync[#{params[:f5]}]", :delayed
     end
@@ -26,7 +28,7 @@ define :f5_vip, :member_port => 443, :monitors => [], :lb_method => nil, :vlan_s
   pool_members = params[:nodes].map { |n| { 'address' => n, 'port' => params[:member_port], 'enabled' => true } }
 
   f5_ltm_pool "#{params[:f5]}-#{params[:pool]}" do
-    pool_name params[:pool]
+    pool_name "#{params[:partition]}/#{params[:pool]}"
     f5 params[:f5]
     lb_method params[:lb_method] unless params[:lb_method].nil?
     monitors params[:monitors] unless params[:monitors].empty?
@@ -35,7 +37,7 @@ define :f5_vip, :member_port => 443, :monitors => [], :lb_method => nil, :vlan_s
   end
 
   f5_ltm_virtual_server "#{params[:f5]}-#{name}" do
-    vs_name name
+    vs_name "#{params[:partition]}/#{name}"
     f5 params[:f5]
     destination_address params[:destination_address]
     destination_port params[:destination_port]

--- a/libraries/load_balancer.rb
+++ b/libraries/load_balancer.rb
@@ -41,10 +41,10 @@ module F5
       end
       return if @active_partition == partition
 
+      @ltm = nil
       Chef::Log.info "Setting #{partition} as active partition"
       @client['Management.Partition'].set_active_partition(partition)
       @active_partition = partition
-      @ltm = nil
     end
 
     #

--- a/libraries/load_balancer.rb
+++ b/libraries/load_balancer.rb
@@ -25,11 +25,12 @@ require 'load_balancer/ltm'
 module F5
   # The F5 device
   class LoadBalancer
-    attr_accessor :name, :client
+    attr_accessor :name, :client, :active_partition
 
     def initialize(name, client)
       @name = name
       @client = client
+      @active_partition = @client['Management.Partition'].get_active_partition
     end
 
     def change_partition(partition='Common')
@@ -38,8 +39,12 @@ module F5
       else
         partition = 'Common'
       end
+      return if @active_partition == partition
+
       Chef::Log.info "Setting #{partition} as active partition"
       @client['Management.Partition'].set_active_partition(partition)
+      @active_partition = partition
+      @ltm = nil
     end
 
     #

--- a/libraries/load_balancer.rb
+++ b/libraries/load_balancer.rb
@@ -29,8 +29,8 @@ module F5
 
     def initialize(name, client)
       @name = name
+      @active_partition = client['Management.Partition'].get_active_partition
       @client = client
-      @active_partition = @client['Management.Partition'].get_active_partition
     end
 
     def change_partition(partition='Common')

--- a/libraries/load_balancer.rb
+++ b/libraries/load_balancer.rb
@@ -39,12 +39,13 @@ module F5
       else
         partition = 'Common'
       end
-      return if @active_partition == partition
+      return true if @active_partition == partition
 
       @ltm = nil
       Chef::Log.info "Setting #{partition} as active partition"
       @client['Management.Partition'].set_active_partition(partition)
       @active_partition = partition
+      return true
     end
 
     #

--- a/libraries/load_balancer.rb
+++ b/libraries/load_balancer.rb
@@ -32,6 +32,15 @@ module F5
       @client = client
     end
 
+    def change_partition(partition='Common')
+      if partition.include?('/')
+        partition = partition.split('/')[1]
+      else
+        partition = 'Common'
+      end
+      @client['Management.Partition'].set_active_partition(partition)
+    end
+
     #
     # LTM resources for load balancer
     #

--- a/libraries/load_balancer.rb
+++ b/libraries/load_balancer.rb
@@ -38,6 +38,7 @@ module F5
       else
         partition = 'Common'
       end
+      Chef::Log.info "Setting #{partition} as active partition"
       @client['Management.Partition'].set_active_partition(partition)
     end
 

--- a/libraries/load_balancer/ltm.rb
+++ b/libraries/load_balancer/ltm.rb
@@ -32,21 +32,29 @@ module F5
       end
 
       def nodes # rubocop:disable MethodLength
-        @nodes ||= begin
-          node_list = client['LocalLB.NodeAddressV2'].get_list
+        @nodes = []
+        node_list = {}
+        partitions = client['Management.Partition'].get_partition_list
+        partitions.each do |partition|
+          node_list[partition['partition_name']] = client['LocalLB.NodeAddressV2'].get_list
+          next if node_list[partition['partition_name']].empty?
 
-          # Check if empty
-          return [] if node_list.empty?
-
-          addresses = client['LocalLB.NodeAddressV2'].get_address(node_list)
-          statuses = client['LocalLB.NodeAddressV2'].get_object_status(node_list)
-
+          addresses = client['LocalLB.NodeAddressV2'].get_address(node_list[partition['partition_name']])
+          statuses = client['LocalLB.NodeAddressV2'].get_object_status(node_list[partition['partition_name']])
           states = statuses.map { |status| status['enabled_status'] != 'ENABLED_STATUS_DISABLED' }
 
-          node_list.each_with_index.map do |node, index|
-            { 'name' => node, 'address' => addresses[index], 'enabled' => states[index] }
+          node_list[partition['partition_name']].each_with_index.map do |node, index|
+            @nodes << { 'name' => node, 'address' => addresses[index], 'enabled' => states[index], 'partition' => partition['partition_name'] }
           end
         end
+        return @nodes
+      end
+
+      def partitions
+        client['Management.Partition'].get_partition_list.each do |p|
+          parts << p['partition_name']
+        end
+        @partitions ||= parts
       end
 
       def pools

--- a/libraries/load_balancer/ltm.rb
+++ b/libraries/load_balancer/ltm.rb
@@ -60,6 +60,13 @@ module F5
       def monitors
         @monitors ||= F5::LoadBalancer::Ltm::Monitors.new(client)
       end
+
+      def partitions
+        client['Management.Partition'].get_partition_list.each do |p|
+          parts << p['partition_name']
+        end
+        @partitions ||= parts
+      end
     end
   end
 end

--- a/libraries/load_balancer/ltm/pools.rb
+++ b/libraries/load_balancer/ltm/pools.rb
@@ -34,8 +34,6 @@ module F5
 
         def initialize(client)
           @client = client
-          @partitions = client['Management.Partition'].get_partition_list
-
           refresh_all
         end
 
@@ -115,16 +113,12 @@ module F5
         end
 
         def refresh_all
-          @pools = [] if @pools.nil? 
-          @partitions.each do |partition|
-            @client['Management.Partition'].set_active_partition(partition['partition_name'])
-            @pools += @client['LocalLB.Pool'].get_list
+          @pools = @client['LocalLB.Pool'].get_list
                                           .map { |p| F5::LoadBalancer::Ltm::Pools::Pool.new(p) }
-            next if @pools.empty?
-            refresh_members
-            refresh_monitors
-            refresh_lb_method
-          end
+          return if @pools.empty?
+          refresh_members
+          refresh_monitors
+          refresh_lb_method
         end
       end
     end

--- a/libraries/load_balancer/ltm/pools.rb
+++ b/libraries/load_balancer/ltm/pools.rb
@@ -34,6 +34,8 @@ module F5
 
         def initialize(client)
           @client = client
+          @partitions = client['Management.Partition'].get_partition_list
+
           refresh_all
         end
 
@@ -113,12 +115,16 @@ module F5
         end
 
         def refresh_all
-          @pools = @client['LocalLB.Pool'].get_list
+          @pools = [] if @pools.nil? 
+          @partitions.each do |partition|
+            @client['Management.Partition'].set_active_partition(partition['partition_name'])
+            @pools += @client['LocalLB.Pool'].get_list
                                           .map { |p| F5::LoadBalancer::Ltm::Pools::Pool.new(p) }
-          return if @pools.empty?
-          refresh_members
-          refresh_monitors
-          refresh_lb_method
+            next if @pools.empty?
+            refresh_members
+            refresh_monitors
+            refresh_lb_method
+          end
         end
       end
     end

--- a/libraries/load_balancer/ltm/pools.rb
+++ b/libraries/load_balancer/ltm/pools.rb
@@ -76,7 +76,6 @@ module F5
           pools_members.each_with_index do |pool_members, idx|
             pool_members.each { |m| @pools[idx].members << F5::LoadBalancer::Ltm::Pools::Pool::Member.new(m) }
           end
-
           # Automatically update members states
           # refresh_member_status
         end

--- a/libraries/loader.rb
+++ b/libraries/loader.rb
@@ -56,7 +56,8 @@ module F5
         'Management.DeviceGroup',
         'System.ConfigSync',
         'System.Failover',
-        'System.Inet'
+        'System.Inet',
+        'Management.Partition'
       ]
     end
 

--- a/libraries/loader.rb
+++ b/libraries/loader.rb
@@ -56,8 +56,7 @@ module F5
         'Management.DeviceGroup',
         'System.ConfigSync',
         'System.Failover',
-        'System.Inet',
-        'Management.Partition'
+        'System.Inet'
       ]
     end
 

--- a/libraries/loader.rb
+++ b/libraries/loader.rb
@@ -49,6 +49,7 @@ module F5
     #
     def interfaces
       [
+        'Management.Partition',
         'LocalLB.Monitor',
         'LocalLB.NodeAddressV2',
         'LocalLB.Pool',
@@ -56,8 +57,7 @@ module F5
         'Management.DeviceGroup',
         'System.ConfigSync',
         'System.Failover',
-        'System.Inet',
-        'Management.Partition'
+        'System.Inet'
       ]
     end
 

--- a/libraries/provider_ltm_monitor.rb
+++ b/libraries/provider_ltm_monitor.rb
@@ -36,7 +36,8 @@ class Chef
         @current_resource.name(@new_resource.name)
         @current_resource.monitor_name(@new_resource.monitor_name)
 
-        monitor = load_balancer.ltm.monitors.find { |m| m.name =~ /(^|\/)#{@new_resource.monitor_name}$/ }
+        load_balancer.change_partition(@new_resource.monitor_name) 
+        monitor = load_balancer.ltm.monitors.find { |m| m.name =~ /(^|\/)#{@new_resource.monitor_name}$/ or m.name == @new_resource.monitor_name }
         @current_resource.exists = !monitor.nil?
         return @current_resource unless @current_resource.exists
 

--- a/libraries/provider_ltm_node.rb
+++ b/libraries/provider_ltm_node.rb
@@ -37,7 +37,7 @@ class Chef
         @current_resource.node_name(@new_resource.node_name)
 
         # Check if node exists
-        node = load_balancer.ltm.nodes.find { |n| n['name'] =~ /(^|\/)#{@new_resource.node_name}$/ or n['name'] == @new_resource.node_name }
+        node = load_balancer.ltm.nodes.find { |n| n['name'] =~ /(^|\/)#{@new_resource.node_name}$/ }
         @current_resource.exists = !node.nil?
 
         # If node exists load it's current state

--- a/libraries/provider_ltm_node.rb
+++ b/libraries/provider_ltm_node.rb
@@ -37,7 +37,8 @@ class Chef
         @current_resource.node_name(@new_resource.node_name)
 
         # Check if node exists
-        node = load_balancer.ltm.nodes.find { |n| n['name'] =~ /(^|\/)#{@new_resource.node_name}$/ }
+        load_balancer.change_partition(@new_resource.node_name) 
+        node = load_balancer.ltm.nodes.find { |n| n['name'] =~ /(^|\/)#{@new_resource.node_name}$/ or n['name'] == @new_resource.node_name }
         @current_resource.exists = !node.nil?
 
         # If node exists load it's current state

--- a/libraries/provider_ltm_node.rb
+++ b/libraries/provider_ltm_node.rb
@@ -37,7 +37,7 @@ class Chef
         @current_resource.node_name(@new_resource.node_name)
 
         # Check if node exists
-        load_balancer.change_partition(@new_resource.node_name) 
+        load_balancer.change_partition(@new_resource.node_name)
         node = load_balancer.ltm.nodes.find { |n| n['name'] =~ /(^|\/)#{@new_resource.node_name}$/ or n['name'] == @new_resource.node_name }
         @current_resource.exists = !node.nil?
 

--- a/libraries/provider_ltm_node.rb
+++ b/libraries/provider_ltm_node.rb
@@ -37,7 +37,7 @@ class Chef
         @current_resource.node_name(@new_resource.node_name)
 
         # Check if node exists
-        node = load_balancer.ltm.nodes.find { |n| n['name'] =~ /(^|\/)#{@new_resource.node_name}$/ }
+        node = load_balancer.ltm.nodes.find { |n| n['name'] =~ /(^|\/)#{@new_resource.node_name}$/ or n['name'] == @new_resource.node_name }
         @current_resource.exists = !node.nil?
 
         # If node exists load it's current state

--- a/libraries/provider_ltm_pool.rb
+++ b/libraries/provider_ltm_pool.rb
@@ -36,7 +36,8 @@ class Chef
         @current_resource.name(@new_resource.name)
         @current_resource.pool_name(@new_resource.pool_name)
 
-        pool = load_balancer.ltm.pools.find { |p| p.name =~ /(^|\/)#{@new_resource.pool_name}$/ }
+        load_balancer.change_partition(@new_resource.pool_name) 
+        pool = load_balancer.ltm.pools.find { |p| p.name =~ /(^|\/)#{@new_resource.pool_name}$/ or p.name == @new_resource.pool_name }
 
         @current_resource.exists = !pool.nil?
 

--- a/libraries/provider_ltm_pool.rb
+++ b/libraries/provider_ltm_pool.rb
@@ -32,11 +32,11 @@ class Chef
       end
 
       def load_current_resource # rubocop:disable MethodLength
+        load_balancer.change_partition(@new_resource.pool_name) 
         @current_resource = Chef::Resource::F5LtmPool.new(@new_resource.name)
         @current_resource.name(@new_resource.name)
         @current_resource.pool_name(@new_resource.pool_name)
 
-        load_balancer.change_partition(@new_resource.pool_name) 
         pool = load_balancer.ltm.pools.find { |p| p.name =~ /(^|\/)#{@new_resource.pool_name}$/ or p.name == @new_resource.pool_name }
 
         @current_resource.exists = !pool.nil?
@@ -77,6 +77,7 @@ class Chef
             { 'address' => member['address'], 'port' => member['port'] }
           end
 
+          load_balancer.change_partition(new_resource.pool_name) 
           load_balancer.client['LocalLB.Pool'].create_v2([new_resource.pool_name], [new_resource.lb_method], [members])
 
           current_resource.lb_method(new_resource.lb_method)

--- a/libraries/provider_ltm_pool.rb
+++ b/libraries/provider_ltm_pool.rb
@@ -32,11 +32,11 @@ class Chef
       end
 
       def load_current_resource # rubocop:disable MethodLength
-        load_balancer.change_partition(@new_resource.pool_name) 
         @current_resource = Chef::Resource::F5LtmPool.new(@new_resource.name)
         @current_resource.name(@new_resource.name)
         @current_resource.pool_name(@new_resource.pool_name)
 
+        load_balancer.change_partition(@new_resource.pool_name) 
         pool = load_balancer.ltm.pools.find { |p| p.name =~ /(^|\/)#{@new_resource.pool_name}$/ or p.name == @new_resource.pool_name }
 
         @current_resource.exists = !pool.nil?

--- a/libraries/provider_ltm_pool.rb
+++ b/libraries/provider_ltm_pool.rb
@@ -36,7 +36,7 @@ class Chef
         @current_resource.name(@new_resource.name)
         @current_resource.pool_name(@new_resource.pool_name)
 
-        pool = load_balancer.ltm.pools.find { |p| p.name =~ /(^|\/)#{@new_resource.pool_name}$/ }
+        pool = load_balancer.ltm.pools.find { |p| p.name =~ /(^|\/)#{@new_resource.pool_name}$/ or p.name == @new_resource.pool_name }
 
         @current_resource.exists = !pool.nil?
 

--- a/libraries/provider_ltm_pool.rb
+++ b/libraries/provider_ltm_pool.rb
@@ -36,7 +36,7 @@ class Chef
         @current_resource.name(@new_resource.name)
         @current_resource.pool_name(@new_resource.pool_name)
 
-        pool = load_balancer.ltm.pools.find { |p| p.name =~ /(^|\/)#{@new_resource.pool_name}$/ or p.name == @new_resource.pool_name }
+        pool = load_balancer.ltm.pools.find { |p| p.name =~ /(^|\/)#{@new_resource.pool_name}$/ }
 
         @current_resource.exists = !pool.nil?
 

--- a/libraries/provider_ltm_virtual_server.rb
+++ b/libraries/provider_ltm_virtual_server.rb
@@ -38,7 +38,8 @@ class Chef
         @current_resource.default_persistence_profile_cnt = 0
 
         # Check if virtual server exists
-        vs = load_balancer.ltm.virtual_servers.find { |v| v.name =~ /(^|\/)#{@new_resource.vs_name}$/ }
+        load_balancer.change_partition(@new_resource.vs_name)
+        vs = load_balancer.ltm.virtual_servers.find { |v| v.name =~ /(^|\/)#{@new_resource.vs_name}$/ or v.name == @new_resource.vs_name }
 
         @current_resource.exists = !vs.nil?
         return @current_resource unless @current_resource.exists

--- a/spec/libraries/load_balancer_spec.rb
+++ b/spec/libraries/load_balancer_spec.rb
@@ -24,8 +24,6 @@ module F5
                                         .and_return(system_failover)
       allow(client).to receive(:[]).with('System.Inet')
                                         .and_return(system_inet)
-      allow(client).to receive(:[]).with('Management.Partition')
-                                        .and_return(system_inet)
     end
 
     describe '#ltm' do
@@ -33,10 +31,17 @@ module F5
         load_balancer.instance_variable_set(:@ltm, 'test')
         expect(F5::LoadBalancer::Ltm).to_not receive(:new)
         expect(load_balancer.ltm).to eq('test')
+        expect(load_balancer.active_partition).to eq('Common')
       end
 
       it 'sets @ltm if not already set and then returns it' do
         expect(load_balancer.ltm).to be_a(F5::LoadBalancer::Ltm)
+      end
+    end
+
+    describe '#change_partition' do
+      it 'returns the active partition' do
+        expect(load_balancer.change_partition).to eq('Common')
       end
     end
 

--- a/spec/libraries/load_balancer_spec.rb
+++ b/spec/libraries/load_balancer_spec.rb
@@ -45,8 +45,8 @@ module F5
     end
 
     describe '#change_partition' do
-      it 'returns the active partition' do
-        expect(load_balancer.change_partition).to eq('Common')
+      it 'changes the active partition' do
+        expect(load_balancer.change_partition).to eq(true)
       end
     end
 

--- a/spec/libraries/load_balancer_spec.rb
+++ b/spec/libraries/load_balancer_spec.rb
@@ -24,6 +24,8 @@ module F5
                                         .and_return(system_failover)
       allow(client).to receive(:[]).with('System.Inet')
                                         .and_return(system_inet)
+      allow(client).to receive(:[]).with('Management.Partition')
+                                        .and_return(system_inet)
     end
 
     describe '#ltm' do

--- a/spec/libraries/load_balancer_spec.rb
+++ b/spec/libraries/load_balancer_spec.rb
@@ -14,6 +14,9 @@ module F5
     let(:system_inet) do
       double 'System.Inet', :get_hostname => 'test-f5.test.com'
     end
+    let(:management_partition) do
+      double 'Management.Partition', :get_active_partition => 'Common'
+    end
 
     let(:load_balancer) { F5::LoadBalancer.new('test-f5', client) }
 
@@ -24,6 +27,8 @@ module F5
                                         .and_return(system_failover)
       allow(client).to receive(:[]).with('System.Inet')
                                         .and_return(system_inet)
+      allow(client).to receive(:[]).with('Management.Partition')
+                                        .and_return(management_partition)
     end
 
     describe '#ltm' do

--- a/spec/libraries/loader_spec.rb
+++ b/spec/libraries/loader_spec.rb
@@ -34,6 +34,7 @@ module F5
 
     let(:wanted_interfaces) do
       [
+        'Management.Partition',
         'LocalLB.Monitor',
         'LocalLB.NodeAddressV2',
         'LocalLB.Pool',
@@ -41,8 +42,7 @@ module F5
         'Management.DeviceGroup',
         'System.ConfigSync',
         'System.Failover',
-        'System.Inet',
-        'Management.Partition'
+        'System.Inet'
       ]
     end
 

--- a/spec/libraries/loader_spec.rb
+++ b/spec/libraries/loader_spec.rb
@@ -41,7 +41,8 @@ module F5
         'Management.DeviceGroup',
         'System.ConfigSync',
         'System.Failover',
-        'System.Inet'
+        'System.Inet',
+        'Management.Partition'
       ]
     end
 

--- a/spec/testing_recipes/default_spec.rb
+++ b/spec/testing_recipes/default_spec.rb
@@ -7,9 +7,9 @@ describe 'testing::default' do
     config_sync_f5 = chef_run.f5_config_sync('test-f5.test.com')
     expect(config_sync_f5).to do_nothing
     expect(chef_run).to create_f5_ltm_node('test-f5.test.com-10.10.10.10')
-      .with(:node_name => '10.10.10.10', :f5 => 'test-f5.test.com', :enabled => true)
+      .with(:node_name => '/Common/10.10.10.10', :f5 => 'test-f5.test.com', :enabled => true)
     expect(chef_run).to create_f5_ltm_node('test-f5.test.com-10.10.10.11')
-      .with(:node_name => '10.10.10.11', :f5 => 'test-f5.test.com', :enabled => true)
+      .with(:node_name => '/Common/10.10.10.11', :f5 => 'test-f5.test.com', :enabled => true)
     expect(chef_run).to create_f5_ltm_pool('test-f5.test.com-test-pool')
       .with(:pool_name => 'test-pool', :f5 => 'test-f5.test.com', :lb_method => 'LB_METHOD_ROUND_ROBIN', :monitors => [],
             :members => [{ 'address' => '10.10.10.10', 'port' => 443, 'enabled' => true },


### PR DESCRIPTION
I've added support for partitions. The syntax is pretty straightforward. Let's say your partitions is called "webpartition". Just prepend all names with that!

f5_ltm_node '/webpartition/webserver01' do
  address '192.168.10.1'
  f5 '1.1.1.1'
  enabled true
end

f5_ltm_pool '/webpartition/testb_web' do
  f5 '1.1.1.1'
  lb_method 'LB_METHOD_ROUND_ROBIN'
  monitors ['tcp']
  members [
    {
      'address'   => '/webpartition/webserver01',
      'port'      => 6000,
      'enabled'   => true
    }
  ]
end

f5_ltm_virtual_server '/webpartition/id.testb' do
  f5 '1.1.1.1'
  destination_address '192.168.100.1'
  destination_port 80
  default_pool '/webpartition/testb_web'
  enabled true
end