### PR TITLE
Modify `ltm_virtual_server` resource to reduce unnecessary converges

### DIFF
--- a/libraries/provider_ltm_virtual_server.rb
+++ b/libraries/provider_ltm_virtual_server.rb
@@ -62,6 +62,7 @@ class Chef
           @current_resource.default_persistence_profile(vs.default_persistence_profile.first['profile_name'])
         end
         @current_resource.fallback_persistence_profile(vs.fallback_persistence_profile)
+        @current_resource.rules(vs.rules)
 
         @current_resource
       end

--- a/libraries/provider_ltm_virtual_server.rb
+++ b/libraries/provider_ltm_virtual_server.rb
@@ -115,7 +115,9 @@ class Chef
         current_val = current_resource.send(attr)
         new_val = new_resource.send(attr)
 
-        return true if current_val == new_val
+        # We convert to strings here in case there is a type mismatch
+        # Example: `destination_port` passed as a String but F5 returns FixNum
+        return true if current_val.to_s == new_val.to_s
 
         # Order matters on rules so we cannot do length or intersection check
         if current_val.is_a?(Array) && new_val.is_a?(Array) && attr != 'rules'


### PR DESCRIPTION
This mainly:
  - Modifies the `match?` method to handle order differences between F5 and user attributes
    - Example: User passes`['foo', 'bar']` but F5 returns `['bar', 'foo']`
    - NOTE: This does not apply to iRules (let me know if other exceptions need to be made)
  - Modifies several comparisons to use `match?` instead of `==`
    - Example: `current_resource.vlans == new_resource.vlans` becomes `match?('vlans')`
  - Modifies the `match?` method to convert values to strings before comparing
    - Example: User passes `'443'` for `destination_port` but F5 returns `443`
  - Adds `current_resource.rules`
    - Note: Current implementation never loads rules from F5 so it will always fail `match?` and converge

Let me know if I need to squash these into 1 commit. I separated them for ease of code review.

I can also remove/edit commits as well. This PR does not need to be taken in it's entirety. 